### PR TITLE
PR-7943: Avoid bsTransitionEnd callback if tip is destroyed during "i…

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -487,6 +487,7 @@
     this.hide(function () {
       that.$element.off('.' + that.type).removeData('bs.' + that.type)
       if (that.$tip) {
+        that.$tip.off('bsTransitionEnd'); // PR-7943
         that.$tip.detach()
       }
       that.$tip = null


### PR DESCRIPTION
…n" animation