### PR TITLE
Always apply inline form styling when printing

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -474,7 +474,7 @@ input[type="checkbox"] {
 .form-inline {
 
   // Kick in the inline
-  @media (min-width: @screen-sm-min) {
+  @media (min-width: @screen-sm-min), print {
     // Inline-block all the things for "inline"
     .form-group {
       display: inline-block;


### PR DESCRIPTION
Thanks for pointing me in the right direction here, @timvasil! It's a very concise and effective solution, which I've tested this on Chrome, Firefox, and Safari. (Not sure how best to test on IE, since BrowserStack doesn't entirely expose print functionality, but I'm feeling good about this approach.)