### PR TITLE
Fix data-html attribute being overriden issue

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -84,7 +84,7 @@
   }
 
   Tooltip.prototype.getOptions = function (options) {
-    options = $.extend({}, this.getDefaults(), this.$element.data(), options)
+    options = $.extend({}, this.getDefaults(), options, this.$element.data())
 
     if (options.delay && typeof options.delay == 'number') {
       options.delay = {


### PR DESCRIPTION
This will ensure that if data attributes are set explicitly on an html element (such as `data-html="false"`), then those attributes will be honored when creating the tooltip.